### PR TITLE
Update chalk dependency to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "changelog": "./bin/changelog.js"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
+    "chalk": "^1.1.1",
     "cli": "^0.6.4",
     "has-color": "^0.1.1",
     "lodash": "^2.4.1",


### PR DESCRIPTION
Right now I get a warning every time I `npm install`:

```
npm WARN unmet dependency /node_modules/changelog requires chalk@'^0.5.1' but will load
npm WARN unmet dependency /node_modules/chalk,
npm WARN unmet dependency which is version 1.1.1
```

@dylang 
