### PR TITLE
Add support for GitHub token via API

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -77,7 +77,13 @@ function generate(project, versionRequested) {
         });
     }
 
+// See https://help.github.com/articles/creating-an-access-token-for-command-line-use/
+function setGitHubToken(token) {
+  github.setToken(token);
+}
+
 module.exports = {
+    setGitHubToken: setGitHubToken,
     generate: generate,
     markdown: require('./output/markdown'),
     terminal: require('./output/terminal')

--- a/lib/datasrc/github.js
+++ b/lib/datasrc/github.js
@@ -7,6 +7,8 @@ var log     = require('../log');
 var moment = require('moment');
 var q = require('q');
 
+var authToken = null;
+
 function commitMessages(options) {
     var deferred = q.defer();
 
@@ -24,7 +26,14 @@ function commitMessages(options) {
     var url = 'https://api.github.com/repos/' + project + '/commits?per_page=250';
     log.debug('requesting: ' + url);
 
-    request({uri: url, json: true, headers: {'User-Agent': userAgent}}, function (err, res, data) {
+    var headers = {
+      'User-Agent': userAgent
+    };
+    if (authToken) {
+      headers.Authorization = 'token ' + authToken;
+    }
+
+    request({uri: url, json: true, headers: headers}, function (err, res, data) {
         log.debug('complete: ' + url);
 
         if (err) {
@@ -110,7 +119,12 @@ function changelog(repo, releaseRequested) {
         });
 }
 
+function setToken(token) {
+    authToken = token;
+}
+
 module.exports = {
+    setToken: setToken,
     commitMessages: commitMessages,
     changelog: changelog
 };


### PR DESCRIPTION
This adds support for setting a GitHub authentication token via the API. Doing so increases API rate limits substantially.