### PR TITLE
fix: GitHub URL parsing

### DIFF
--- a/lib/datasrc/github.js
+++ b/lib/datasrc/github.js
@@ -10,8 +10,15 @@ var q = require('q');
 function commitMessages(options) {
     var deferred = q.defer();
 
-    // TODO: better argument check and url fix, or just use npm project name
-    var repoURL = URL.parse(options.repo.replace(/\.git$/, ''));
+    var massagedRepo = options.repo;
+    massagedRepo = massagedRepo.replace('git+https://', 'https://');
+    massagedRepo = massagedRepo.replace('git://', 'https://');
+    // Strip out .git and also any extra URL due to monorepos
+    massagedRepo = massagedRepo.replace(
+        /(https:\/\/github.com\/[^\/]*\/[^\/\.]*).*/,
+        "$1"
+    );
+    var repoURL = URL.parse(massagedRepo);
     var project = repoURL.pathname;
 
     if (!project) {


### PR DESCRIPTION
This enhances GitHub URL parsing to support:
- git://
- git+https://
- monropo (e.g. https://github.com/babel/babel/tree/master/packages/babel-runtime)