### PR TITLE
fix: npm.org now has a different way to request info about scoped packages

### DIFF
--- a/lib/datasrc/npm.js
+++ b/lib/datasrc/npm.js
@@ -32,10 +32,21 @@ var repo = '';
 function packageHistory(moduleName) {
     var deferred = q.defer();
     // Escape / in moduleName to support scoped repositories
-    var url = 'http://registry.npmjs.org/' + moduleName.replace('/', '%2F');
+    var url = 'http://registry.npmjs.org/' + moduleName.replace(/^@[^/]+\//, '');
     log.debug('requesting: ' + url);
 
-    request({ uri: url, json: true }, function (err, res, data) {
+    var query = { 
+        uri: url, 
+        json: true 
+    };
+    var packageScope = moduleName.replace(/^@([^/]+)\/[^/]+$/, '$1');
+    log.debug('scoped package? scope = ' + (packageScope ? packageScope : '(none)'));
+    if (packageScope) {
+        query.headers = {
+            "Npm-Scope": packageScope
+        };
+    }
+    request(query, function (err, res, data) {
         log.debug('complete: ' + url);
 
         if (err) {


### PR DESCRIPTION
via the `Npm-Scope` header. See also https://docs.npmjs.com/misc/registry

Code fixed and works at least for a few of my own scoped packages.