### PR TITLE
support empty repo urls

### DIFF
--- a/lib/datasrc/npm.js
+++ b/lib/datasrc/npm.js
@@ -19,7 +19,7 @@ var repo = '';
             var repoTree = data[branch];
             if (repoTree) {
                 repo = repoTree.url;
-                if (!repo) {
+                if (!repo && repoTree.length) {
                     repoTree = repoTree[0];
                     repo = repoTree.url;
                 }

--- a/test/fixtures/npm-changelog.json
+++ b/test/fixtures/npm-changelog.json
@@ -1147,7 +1147,7 @@
     "email": "dylang@gmail.com"
 }, "repository": {
     "type": "git",
-    "url": "https://github.com/dylang/changelog.git"
+    "url": ""
 }, "users": {
     "dylang": true
 }, "_attachments": {


### PR DESCRIPTION
Some non-open-source npm packages like https://www.npmjs.com/package/bitmovin-player contain repository fields with empty URLs. This PR handles this case which other wise would throw an error.