### PR TITLE
fix crash when (globally installed) changelog tool wants to report an error

### DIFF
--- a/lib/changelog.js
+++ b/lib/changelog.js
@@ -3,6 +3,7 @@
 var npm = require('./datasrc/npm');
 var github = require('./datasrc/github');
 var versionFilter = require('./util/versionFilter');
+var q = require('q');
 var log = require('./log');
 
 function processNpmAndGithubData(data, versionRequested) {
@@ -50,7 +51,9 @@ function processNpmAndGithubData(data, versionRequested) {
 function generate(project, versionRequested) {
 
     if (!project) {
-        return new Error('Need help? --help or more help at https://github.com/dylang/changelog');
+        return q.fcall(function () {
+            throw new Error('No project specified. Need help? --help or more help at https://github.com/dylang/changelog');
+        });
     }
 
     if (project.match(/github.com/)) {
@@ -61,7 +64,9 @@ function generate(project, versionRequested) {
             return github.changelog(repo, versionRequested);
         }
 
-        return new Error('Bad repo url: ' + project);
+        return q.fcall(function () {
+            throw new Error('Bad repo url: ' + project);
+        });
     }
 
     // Scoped npm packages start with an '@' and include a forward slash

--- a/lib/datasrc/npm.js
+++ b/lib/datasrc/npm.js
@@ -13,7 +13,7 @@ function sortDate (a, b) {
 }
 
 function findRepoUrl(data) {
-var repo = '';
+    var repo = '';
     ['repository', 'repositories', 'bugs', 'licenses'].forEach(function(branch){
         if (!repo) {
             var repoTree = data[branch];

--- a/test/changelog.test.js
+++ b/test/changelog.test.js
@@ -1,5 +1,6 @@
 "use strict";
 var expect = require('chai').expect;
+var assert = require('chai').assert;
 var proxyquire = require('proxyquire');
 
 var changelog = proxyquire('../lib/changelog', {
@@ -20,7 +21,7 @@ xdescribe('changelog', function() {
         .done(done);
     });
 
-    it('should be able to fomat the results as markdown', function (done) {
+    it('should be able to format the results as markdown', function (done) {
         changelog.generate('changelog', 'latest')
             .then(changelog.markdown)
             .then(function (results) {
@@ -30,7 +31,7 @@ xdescribe('changelog', function() {
         .done(done);
     });
 
-    it('should be able to fomat the results for the terminal', function (done) {
+    it('should be able to format the results for the terminal', function (done) {
         changelog.generate('changelog', 'latest')
             .then(changelog.terminal)
             .then(function (results) {
@@ -39,4 +40,22 @@ xdescribe('changelog', function() {
         .catch(function(err){throw err;})
         .done(done);
     });
+
+    it('should also send errors like "no project" through a promise', function (done) {
+        var count = 0;
+        changelog.generate(null, null, 'latest').then(function (results) {
+            assert.ok(false, "should never get here");
+        })
+        .catch(function(err){
+            count++;
+            assert.equal(count, 1);
+            assert(err.message.includes("No project specified."));
+        })
+        .then(function () {
+            count++;
+            assert.equal(count, 2);
+        })
+        .done(done);
+    });
+
 });


### PR DESCRIPTION
This happens, for instance, when globally installing `changelog` and running it without any argument in a directory where it cannot find a package.json or other means to detect a 'project'. The internal code then returns `Error` instances instead of a promise, as otherwise expected by the `cli.js` code. Which, consequently, crashes.

Code fixes:

- fix: return failures (Errors ~ thrown as exceptions) through the same promise as any positive result.
- fix: typos in test descriptions
- add tests for the fix to prevent regression
